### PR TITLE
Update Beast Stinger DC

### DIFF
--- a/data/harvesting-components.json
+++ b/data/harvesting-components.json
@@ -363,7 +363,7 @@
     {
         "creatureType": "Beast",
         "name": "Beast Stinger",
-        "dc": 5,
+        "dc": 15,
         "id": "QFG2nvKjMeb3A9in",
         "img": "icons/creatures/claws/claw-curved-jagged-yellow.webp",
         "crafting": true,


### PR DESCRIPTION
Updating the Beast Stinger DC from 5 to 15 to match the harvesting table in chapter 4.

Resolves issue #12  - https://github.com/Loot-Foundry/helianas-harvesting/issues/12#issue-2688363798